### PR TITLE
Prepare to bootstrap from stubs to reflection

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -79,13 +79,25 @@ jobs:
   build:
     name: Build .NET executable
     runs-on: ubuntu-latest
-    container: ghul/devcontainer:dotnet
+
+    container:
+      image: mcr.microsoft.com/dotnet/sdk:5.0
+
     timeout-minutes: 10
     needs: [version]
 
     steps:
     - uses: actions/checkout@v2
-                    
+
+    - name: Add .NET tools to PATH
+      run: echo "${HOME}/.dotnet/tools" >> $GITHUB_PATH
+
+    - name: Add GitHub NuGet package source
+      run: dotnet nuget add source https://nuget.pkg.github.com/degory/index.json -n github -u degory -p ${{ secrets.GH_PACKAGES_RO }} --store-password-in-clear-text
+
+    - name: Install stable compiler
+      run: dotnet tool install --global ghul.compiler
+
     - name: Pack
       run: dotnet pack -p:Version=${{ needs.version.outputs.package }}
 

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -3,12 +3,21 @@
 name: CI/CD
 
 on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Version number'
+        required: true
+
   pull_request:
   push:
-    branches:
-      - "main"
+    branches: [master, main]
+
 env:
   CI: true
+  DOTNET_SKIP_FIRST_TIME_EXPERIENCE: 1
+  DOTNET_CLI_TELEMETRY_OPTOUT: 1
+  DOTNET_NOLOGO: 1
 
 jobs:
   version:
@@ -16,7 +25,8 @@ jobs:
     runs-on: ubuntu-20.04
     timeout-minutes: 1
     outputs:
-      number: ${{ steps.mangle_version_number.outputs.version }}
+      tag: ${{ steps.pick_version.outputs.tag }}
+      package: ${{ steps.pick_version.outputs.package }}
 
     steps:
     - uses: actions/checkout@v2
@@ -26,23 +36,45 @@ jobs:
       uses: anothrNick/github-tag-action@1.33.0
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        WITH_V: false
+        WITH_V: true
         DEFAULT_BUMP: patch
         RELEASE_BRANCHES: main,master
-        PRERELEASE_SUFFIX: pre
 
-    - name: Fail if version number is not valid
-      if: ${{ steps.create_version_number.outputs.new_tag == 'v0.0.0' || steps.create_version_number.outputs.new_tag == '' }}
-      run: exit 1
+    - name: Pick version
+      id: pick_version
+      run: |
+        VALID_VERSION_REGEX="^v[0-9]+\.[0-9]+\.[0-9]+(-[A-Za-z0-9]+\.[0-9]+)?$"
 
-    - name: Mangle version number
-      id: mangle_version_number
-      run: echo "::set-output name=version::${VERSION/-pre\./-pre}"
+        if [ ! -z "${MANUAL_VERSION}" ] ; then
+          echo "User supplied version: ${MANUAL_VERSION}"
+
+          VERSION="${MANUAL_VERSION}"
+        elif [ ! -z "${TAG_VERSION}" ] ; then
+          echo "Tag bump generated version: ${TAG_VERSION}"
+
+          VERSION="${TAG_VERSION}"
+        else
+          echo "Neither manual or tag version set"
+          exit 1
+        fi
+
+        if [[ ${VERSION} =~ ${VALID_VERSION_REGEX} ]] && [ "${VERSION}" != "v0.0.0" ] ; then
+          echo "Version number is valid: ${VERSION}"
+          echo "::set-output name=tag::${VERSION}"
+          echo "::set-output name=package::${VERSION:1}"
+        else
+          echo "Version number is not valid ${VERSION}"
+          exit 1
+        fi
+
       env:
-        VERSION: ${{ steps.create_version_number.outputs.new_tag }}         
+        TAG_VERSION: ${{ steps.create_version_number.outputs.new_tag }}
+        MANUAL_VERSION: ${{ github.event.inputs.version }}        
 
-    - name: Echo version number
-      run: echo ${{ steps.mangle_version_number.outputs.version }}
+    - name: Echo version numbers
+      run: |
+        echo "tag version: ${{ steps.pick_version.outputs.tag }}"
+        echo "package version: ${{ steps.pick_version.outputs.package }}"
 
   build:
     name: Build .NET executable
@@ -55,7 +87,7 @@ jobs:
     - uses: actions/checkout@v2
                     
     - name: Pack
-      run: dotnet pack -p:Version=${{ needs.version.outputs.number }}
+      run: dotnet pack -p:Version=${{ needs.version.outputs.package }}
 
     - name: Upload .NET package artefact
       if: ${{ github.event_name != 'push' }}
@@ -65,7 +97,6 @@ jobs:
         path: nupkg
 
     - name: Publish package to GitHub
-      # if: ${{ github.event_name == 'push' }}
       run: dotnet nuget push ./nupkg/*.nupkg -k ${GITHUB_TOKEN} -s https://nuget.pkg.github.com/degory/index.json --skip-duplicate --no-symbols true
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/ghul-test.ghulproj
+++ b/ghul-test.ghulproj
@@ -8,7 +8,7 @@
     <PackageId>ghul.test</PackageId>
     <Authors>degory</Authors>
     <Company>ghul.io</Company>
-    <Version>0.0.1-pre2</Version>
+    <Version>0.0.1-alpha.5</Version>
 
     <PackageOutputPath>./nupkg</PackageOutputPath>
     <RepositoryUrl>https://github.com/degory/ghul-test</RepositoryUrl>

--- a/ghul-test.ghulproj
+++ b/ghul-test.ghulproj
@@ -16,6 +16,8 @@
     <IsTool>true</IsTool>
     <PackAsTool>true</PackAsTool>
     <ToolCommandName>ghul-test</ToolCommandName>
+    <GhulCompiler>ghul-compiler</GhulCompiler>
+    <EnableDefaultCompileItems>false</EnableDefaultCompileItems>
   </PropertyGroup>
 
   <ItemGroup>
@@ -23,24 +25,65 @@
     <PackageReference Include="ghul.runtime" Version="*" />
   </ItemGroup>
 
+  <ItemGroup>
+    <Compile Include="src\**\*.ghul" />
+  </ItemGroup>
+
   <Target Name="CreateManifestResourceNames" />
 
-  <Target Name="GhulAssembliesJson" BeforeTargets="CoreCompile" DependsOnTargets="FindReferenceAssembliesForReferences">
+  <!-- FIXME: share this target -->
+  <Target Name="GhulAssembliesJson"  DependsOnTargets="FindReferenceAssembliesForReferences">
     <PropertyGroup>
       <Assemblies>{"assemblies": [@(ReferencePathWithRefAssemblies -> '"%(fullpath)"', ',')]}</Assemblies>
     </PropertyGroup>
 
     <WriteLinesToFile File=".assemblies.json" Lines="$(Assemblies)" Overwrite="true" Encoding="Utf-8" />
     <Message Importance="high" Text="updated $(OutputFile) with referenced assemblies" />
-
   </Target>  
 
-  <Target Name="CoreCompile">
-    <ItemGroup>
-      <GhulSources Include="src/**/*.ghul" />
-    </ItemGroup>
+  <!-- FIXME: share this target -->
+  <Target Name="CoreCompile" DependsOnTargets="$(CoreCompileDependsOn)"
+    Inputs="
+      $(MSBuildAllProjects);
+      @(Compile);
+      @(_CoreCompileResourceInputs);
+      $(ApplicationIcon);
+      $(AssemblyOriginatorKeyFile);
+      @(ReferencePathWithRefAssemblies);
+      @(CompiledLicenseFile);
+      @(LinkResource);
+      @(EmbeddedDocumentation);
+      $(Win32Resource);
+      $(Win32Manifest);
+      @(CustomAdditionalCompileInputs);
+      $(ResolvedCodeAnalysisRuleSet);
+      @(AdditionalFiles);
+      @(EmbeddedFiles);
+      @(EditorConfigFiles)"
+    Outputs="
+      @(DocFileItem);
+      @(IntermediateAssembly);
+      @(IntermediateRefAssembly);
+      @(_DebugSymbolsIntermediatePath);
+      $(NonExistentFile);
+      @(CustomAdditionalCompileOutputs)">
 
-    <Exec Command="ghul --v3 @(GhulSources -> '%(fullpath)', '%20') -o $(IntermediateOutputPath)$(AssemblyName).dll @(ReferencePathWithRefAssemblies -> '--assembly %(fullpath)', '%20')" />
+    <PropertyGroup>
+      <ReleaseOption Condition="'$(CI)' != ''">--define release</ReleaseOption>
+
+      <CommandLine>--v3 @(Compile -> '%(fullpath)', '%20') -o $(IntermediateOutputPath)$(AssemblyName).dll @(ReferencePathWithRefAssemblies -> '--assembly %(fullpath)', '%20')</CommandLine>
+    </PropertyGroup>
+
+    <WriteLinesToFile File="build.txt" Lines="$(CommandLine)" Overwrite="true" Encoding="Utf-8" />
+
+    <Message Importance="high" Text="using compiler $(GhulCompiler)" />
+    <Message Importance="high" Text="release option /$(ReleaseOption)/" />
+
+    <Message Importance="low" Text="$(CommandLine)" />
+
+    <Exec Command="$(GhulCompiler) $(ReleaseOption) @build.txt" />
+
+    <Delete Files="build.txt" />
 
     <Copy SourceFiles="$(ProjectDir)$(IntermediateOutputPath)$(AssemblyName).dll" DestinationFolder="$(ProjectDir)$(IntermediateOutputPath)ref" />
   </Target>

--- a/src/runner.ghul
+++ b/src/runner.ghul
@@ -32,14 +32,18 @@ namespace Tester is
 
         _test: TEST;
 
+        _runtime_path: string;
+
         init(
             host_cli: string,
             target_cli: string,
+            runtime_path: string,
             use_installed_compiler: bool,
             test: TEST
         ) is
             _host_cli = host_cli;
             _target_cli = target_cli;
+            _runtime_path = runtime_path;
             _use_installed_compiler = use_installed_compiler;
             _test = test;
 
@@ -122,6 +126,8 @@ namespace Tester is
 
             run_diff_il_out();
 
+            run_ln_runtime();
+
             if !build_succeeded then
                 return;
             fi
@@ -203,13 +209,7 @@ namespace Tester is
         run_compiler() -> bool is
             let arguments = new LIST[string]();
 
-            let ghul_v3_string = System.Environment.get_environment_variable("GHUL_V3"); 
-
-            if ghul_v3_string != null && (ghul_v3_string =~ "1" || ghul_v3_string =~ "true") then
-                arguments.add("--v3");
-            fi
-
-            arguments.add_range(["--library-prefix", get_library_prefix_path()]);
+            arguments.add("--v3");
 
             if _test.flags? && _test.flags.length > 0 then
                 arguments.add_range(
@@ -246,6 +246,21 @@ namespace Tester is
             return File.exists(get_path("binary.exe"));
         si
 
+        run_ln_runtime() -> bool is
+            // let ghul_v3_string = System.Environment.get_environment_variable("GHUL_V3"); 
+
+            // if ghul_v3_string == null || (ghul_v3_string !~ "1" && ghul_v3_string !~ "true") then
+            //     return true;
+            // fi
+
+            return run(
+                "ln",
+                ["-s", _runtime_path, "."],
+                1000,
+                null,
+                null
+            ) != 0;
+        si
 
         run_sed() -> bool =>
             run(

--- a/src/runner.ghul
+++ b/src/runner.ghul
@@ -110,11 +110,9 @@ namespace Tester is
                 fi
             fi
 
-            run_sed();
-
-            run_grep("error:", "sed.out", "err.grep");
+            run_grep("error:", "compiler.out", "err.grep");
                  
-            run_grep("warn:", "sed.out", "warn.grep");
+            run_grep("warn:", "compiler.out", "warn.grep");
 
             run_sort("err.grep", "err.sort");
 
@@ -126,11 +124,11 @@ namespace Tester is
 
             run_diff_il_out();
 
-            run_ln_runtime();
-
             if !build_succeeded then
                 return;
             fi
+
+            run_ln_runtime();
 
             if !run_binary() then
                 return;
@@ -247,12 +245,6 @@ namespace Tester is
         si
 
         run_ln_runtime() -> bool is
-            // let ghul_v3_string = System.Environment.get_environment_variable("GHUL_V3"); 
-
-            // if ghul_v3_string == null || (ghul_v3_string !~ "1" && ghul_v3_string !~ "true") then
-            //     return true;
-            // fi
-
             return run(
                 "ln",
                 ["-s", _runtime_path, "."],
@@ -261,16 +253,6 @@ namespace Tester is
                 null
             ) != 0;
         si
-
-        run_sed() -> bool =>
-            run(
-                "sed",
-                ["-f", get_library_prefix_path() + "/test.sed", "compiler.out"],
-                1000,
-                "sed.out",
-                null,
-                _collate_environment
-            ) != 0;
 
         run_grep(pattern: string, in_file: string, out_file: string) -> bool is
             return

--- a/src/runner.ghul
+++ b/src/runner.ghul
@@ -126,8 +126,6 @@ namespace Tester is
                 return;
             fi
 
-            run_ln_runtime();
-
             if !run_binary() then
                 return;
             fi
@@ -205,8 +203,6 @@ namespace Tester is
         run_compiler() -> bool is
             let arguments = new LIST[string]();
 
-            arguments.add(get_compiler_binary_path());
-
             let ghul_v3_string = System.Environment.get_environment_variable("GHUL_V3"); 
 
             if ghul_v3_string != null && (ghul_v3_string =~ "1" || ghul_v3_string =~ "true") then
@@ -228,7 +224,7 @@ namespace Tester is
             arguments.add_range(["-o", "binary.exe"]);                
             
             let result = run(
-                _host_cli,
+                get_compiler_binary_path(),
                 arguments,
                 5000,
                 null,
@@ -250,21 +246,6 @@ namespace Tester is
             return File.exists(get_path("binary.exe"));
         si
 
-        run_ln_runtime() -> bool is
-            let ghul_v3_string = System.Environment.get_environment_variable("GHUL_V3"); 
-
-            if ghul_v3_string == null || (ghul_v3_string !~ "1" && ghul_v3_string !~ "true") then
-                return true;
-            fi
-
-            return run(
-                "ln",
-                ["-s", get_library_prefix_path() + "/dotnet/ghul-runtime.dll", "."],
-                1000,
-                null,
-                null
-            ) != 0;
-        si
 
         run_sed() -> bool =>
             run(
@@ -476,7 +457,7 @@ namespace Tester is
         
         get_compiler_binary_path() -> string is
             if _use_installed_compiler then
-                return "/usr/bin/ghul.exe";
+                return "ghul-compiler";
             fi
             
             return

--- a/src/test-queue.ghul
+++ b/src/test-queue.ghul
@@ -23,6 +23,8 @@ namespace Tester is
 
         _tests: MutableList[TEST];
 
+        _runtime_path: string;
+
         progress: int;
         count: int => _tests.count;
 
@@ -37,6 +39,8 @@ namespace Tester is
             let requested_test_processes = System.Environment.get_environment_variable("TEST_PROCESSES");
 
             let actual_test_processes: int;
+
+            _runtime_path = get_runtime_path();
 
             if requested_test_processes? then
                 actual_test_processes = System.Convert.to_int32(requested_test_processes);                
@@ -65,6 +69,7 @@ namespace Tester is
                     new RUNNER(
                         _host_cli,
                         _target_cli,
+                        _runtime_path,
                         _use_installed_compiler, 
                         test
                     );
@@ -203,6 +208,20 @@ namespace Tester is
                 fi
 
                 return path;                
-            si);        
+            si);   
+            
+        get_runtime_path() -> string is
+            let executing_assembly = System.Reflection.Assembly.get_executing_assembly();
+
+            let assembly_path = IO.Path.get_full_path(executing_assembly.location);
+
+            let result = IO.Path.get_directory_name(assembly_path);
+
+            if !result.ends_with('/') then
+                result = result + '/';
+            fi
+
+            return result + "ghul-runtime.dll";
+        si        
     si
 si


### PR DESCRIPTION
- Support testing compiler installed as global .NET tool
- Remove support for testing compiler installed globally via Bash installer
- Avoid building repeatedly if source files have not changed
- Don't echo extremely long compiler command line on build error (see degory/ghul#687)