### PR TITLE
Request test format diagnostics

### DIFF
--- a/ghul-test.ghulproj
+++ b/ghul-test.ghulproj
@@ -8,7 +8,7 @@
     <PackageId>ghul.test</PackageId>
     <Authors>degory</Authors>
     <Company>ghul.io</Company>
-    <Version>0.0.1-alpha.5</Version>
+    <Version>0.0.7-alpha.1</Version>
 
     <PackageOutputPath>./nupkg</PackageOutputPath>
     <RepositoryUrl>https://github.com/degory/ghul-test</RepositoryUrl>
@@ -71,7 +71,7 @@
     <PropertyGroup>
       <ReleaseOption Condition="'$(CI)' != ''">--define release</ReleaseOption>
 
-      <CommandLine>--v3 @(Compile -> '%(fullpath)', '%20') -o $(IntermediateOutputPath)$(AssemblyName).dll @(ReferencePathWithRefAssemblies -> '--assembly %(fullpath)', '%20')</CommandLine>
+      <CommandLine>--v3 @(Compile -> '%(fullpath)', '%20') -o $(IntermediateOutputPath)$(AssemblyName).dll @(ReferencePathWithRefAssemblies -> '-a %(fullpath)', '%20')</CommandLine>
     </PropertyGroup>
 
     <WriteLinesToFile File="build.txt" Lines="$(CommandLine)" Overwrite="true" Encoding="Utf-8" />

--- a/src/result.ghul
+++ b/src/result.ghul
@@ -40,7 +40,7 @@ namespace Tester is
 
             if body? && body !~ "" then
                 result = result + ": " + body;
-            fi            
+            fi
 
             return result;
         si
@@ -143,7 +143,7 @@ namespace Tester is
                         result
                             .append("\n    ")
                             .append(line);
-                    od                
+                    od
                 fi
             fi
 

--- a/src/runner.ghul
+++ b/src/runner.ghul
@@ -208,6 +208,7 @@ namespace Tester is
             let arguments = new LIST[string]();
 
             arguments.add("--v3");
+            arguments.add("--test-run");
 
             if _test.flags? && _test.flags.length > 0 then
                 arguments.add_range(

--- a/src/test.ghul
+++ b/src/test.ghul
@@ -28,7 +28,7 @@ namespace Tester is
             self.depth = depth;
             self.flags = flags;
             self.is_build_fail_expected = is_build_fail_expected;
-        si  
+        si
 
         to_string() -> string is
             if result? then


### PR DESCRIPTION
- Pass `--test-run` option on the compiler command line. This tells the compiler to output diagnostic messages with from..to source location in them