### PR TITLE
Avoid package caching problems when used locally

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -3,7 +3,7 @@
   "isRoot": true,
   "tools": {
     "ghul.compiler": {
-      "version": "0.2.154",
+      "version": "0.2.158",
       "commands": [
         "ghul-compiler"
       ]

--- a/ghul-test.ghulproj
+++ b/ghul-test.ghulproj
@@ -17,7 +17,7 @@
     <PackageId>ghul.test</PackageId>
     <Authors>degory</Authors>
     <Company>ghul.io</Company>
-    <Version>0.0.19-alpha.1</Version>
+    <Version>0.0.21-alpha.1</Version>
 
     <PackageOutputPath>./nupkg</PackageOutputPath>
     <IsTool>true</IsTool>

--- a/src/compiler-under-test.ghul
+++ b/src/compiler-under-test.ghul
@@ -1,0 +1,136 @@
+namespace Tester is
+    use System.Exception;
+    use IO.File;
+    use IO.Path;
+    use IO.Directory;
+    use IO.DirectoryInfo;
+
+    use Collections.Iterable;
+    use Collections.LIST;
+
+    class COMPILER_UNDER_TEST is
+        _is_ci: bool;
+        _publish: string;
+        _executable: string;
+        _runtime_path: string;
+        _arguments: Iterable[string];
+
+        init(is_ci: bool) is
+            _is_ci = is_ci;
+
+            if _is_ci then
+                IO.Std.error.write_line("CI is set: expect compiler to be installed as a local tool");
+
+                _executable = "dotnet";
+                _runtime_path = get_ghul_test_runtime_path();
+                _arguments = ["ghul-compiler", "--v3", "--test-run"];
+            else
+                IO.Std.error.write_line("CI is not set: expect compiler to be published in ./publish");
+
+                _publish = find_publish_directory();
+
+                _executable = find_published_compiler();
+                _runtime_path = get_published_compiler_path("ghul-runtime.dll");
+                _arguments = ["--v3", "--test-run"];
+            fi
+
+            IO.Std.error.write_line("compiler: " + [_executable] | .cat(_arguments) );
+            IO.Std.error.write_line("runtime: " + _runtime_path);
+        si
+        
+        run_compiler(runner: RUNNER, test: TEST) -> bool is
+            let arguments = new LIST[string]();
+
+            arguments.add_range(_arguments);
+
+            if test.flags? /\ test.flags.length > 0 then
+                arguments.add_range(
+                    test.flags.split([' ']) | .map((flag) -> string => flag.trim())
+                );
+            fi
+            
+            arguments.add_range(test.source_files);
+
+            arguments.add_range(["-o", "binary.exe"]);                
+            
+            let result = runner.run(
+                _executable,
+                arguments,
+                5000,
+                null,
+                "compiler.out"
+            );
+
+            if !File.exists(runner.get_path("compiler.out")) then
+                throw new Exception("compiler output file not found");
+            fi
+
+            if result != 0 then
+                return false;
+            fi
+
+            if !runner.read_all_text("compiler.out").contains("*** succeeded ***") then
+                throw new Exception("compiler success exit status but success message not found in output");
+            fi
+
+            return File.exists(runner.get_path("binary.exe"));
+        si
+
+        run_ln_runtime(runner: RUNNER) -> bool is
+            return runner.run(
+                "ln",
+                ["-s", _runtime_path, "."],
+                1000,
+                null,
+                null
+            ) != 0;
+        si
+
+        find_publish_directory() -> string =>
+            find_publish_directory(new DirectoryInfo(Directory.get_current_directory()));
+
+        find_publish_directory(from: DirectoryInfo) -> string is
+            if !from? then
+                throw new Exception("could not find a publish directory");
+            fi
+            
+            let publish = from.get_directories("publish") | .first();
+
+            if publish.has_value then
+                return publish.value.full_name;
+            fi
+
+            return find_publish_directory(from.parent);
+        si
+
+        find_published_compiler() -> string is
+            let result = get_published_compiler_path("ghul");
+
+            if File.exists(result) then
+                return result;
+            fi
+
+            result = get_published_compiler_path("ghul.exe");
+
+            if File.exists(result) then
+                return result;
+            fi
+
+            throw new Exception("Could not find published compiler: " 
+                + get_published_compiler_path("[ghul|ghul.exe]"));
+        si
+        
+        get_published_compiler_path(file_name: string) -> string =>
+            Path.join(_publish, file_name);
+
+        get_ghul_test_runtime_path() -> string is
+            let executing_assembly = System.Reflection.Assembly.get_executing_assembly();
+
+            let assembly_path = Path.get_full_path(executing_assembly.location);
+
+            let result = Path.get_directory_name(assembly_path);
+
+            return Path.join(result, "ghul-runtime.dll");
+        si                
+    si
+si

--- a/src/main.ghul
+++ b/src/main.ghul
@@ -19,9 +19,18 @@ namespace Tester is
             let host = get_cli_environment_variable("HOST");
             let target = get_cli_environment_variable("TARGET");
 
-            report_host_and_target(host, target);
+            // report_host_and_target(host, target);
 
-            let queue = new TEST_QUEUE(host, target);
+            let ci_string = 
+                System.Environment.get_environment_variable("CI");
+
+            let is_ci =
+                !string.is_null_or_white_space(ci_string) /\
+                (ci_string =~ "1" \/ ci_string.to_lower() =~ "true");
+
+            let compiler_under_test = new COMPILER_UNDER_TEST(is_ci);
+
+            let queue = new TEST_QUEUE(host, target, is_ci, compiler_under_test);
 
             if arguments.count == 0 then
                 Std.write_line("usage: ghul-test <test-folder>...");

--- a/src/main.ghul
+++ b/src/main.ghul
@@ -16,6 +16,11 @@ namespace Tester is
         entry(arguments: string[]) -> int static is
             Std.output_encoding = new UTF8Encoding();
 
+            if arguments.count == 0 then
+                Std.write_line("usage: ghul-test <test-folder>...");
+                return 1;
+            fi
+            
             let host = get_cli_environment_variable("HOST");
             let target = get_cli_environment_variable("TARGET");
 
@@ -32,11 +37,6 @@ namespace Tester is
 
             let queue = new TEST_QUEUE(host, target, is_ci, compiler_under_test);
 
-            if arguments.count == 0 then
-                Std.write_line("usage: ghul-test <test-folder>...");
-                return 1;
-            fi
-            
             for path in arguments do
                 if !Directory.exists(path) then
                     Std.write_line("not a directory: " + path);

--- a/src/runner.ghul
+++ b/src/runner.ghul
@@ -26,23 +26,19 @@ namespace Tester is
         _target_cli: string;
 
         _failure: FAILURE;
-        _use_installed_compiler: bool;
+        _compiler_under_test: COMPILER_UNDER_TEST;
 
         _test: TEST;
-
-        _runtime_path: string;
 
         init(
             host_cli: string,
             target_cli: string,
-            runtime_path: string,
-            use_installed_compiler: bool,
+            compiler_under_test: COMPILER_UNDER_TEST,
             test: TEST
         ) is
             _host_cli = host_cli;
             _target_cli = target_cli;
-            _runtime_path = runtime_path;
-            _use_installed_compiler = use_installed_compiler;
+            _compiler_under_test = compiler_under_test;
             _test = test;
 
             if !_collate_environment? then
@@ -92,7 +88,7 @@ namespace Tester is
                 return;
             fi
 
-            let build_succeeded = run_compiler();
+            let build_succeeded = _compiler_under_test.run_compiler(self, _test);
 
             if build_succeeded then
                 if _test.is_build_fail_expected then
@@ -126,7 +122,7 @@ namespace Tester is
                 return;
             fi
 
-            run_ln_runtime();
+            _compiler_under_test.run_ln_runtime(self);
 
             if !run_binary() then
                 return;
@@ -202,56 +198,6 @@ namespace Tester is
             fi            
         si
        
-        run_compiler() -> bool is
-            let arguments = new LIST[string]();
-
-            arguments.add("ghul-compiler");
-            arguments.add("--v3");
-            arguments.add("--test-run");
-
-            if _test.flags? /\ _test.flags.length > 0 then
-                arguments.add_range(
-                    _test.flags.split([' ']) | .map((flag) -> string => flag.trim())
-                );
-            fi
-            
-            arguments.add_range(_test.source_files);
-
-            arguments.add_range(["-o", "binary.exe"]);                
-            
-            let result = run(
-                "dotnet",
-                arguments,
-                5000,
-                null,
-                "compiler.out"
-            );
-
-            if !File.exists(get_path("compiler.out")) then
-                throw new Exception("compiler output file not found");
-            fi
-
-            if result != 0 then
-                return false;
-            fi
-
-            if !read_all_text("compiler.out").contains("*** succeeded ***") then
-                throw new Exception("compiler success exit status but success message not found in output");
-            fi
-
-            return File.exists(get_path("binary.exe"));
-        si
-
-        run_ln_runtime() -> bool is
-            return run(
-                "ln",
-                ["-s", _runtime_path, "."],
-                1000,
-                null,
-                null
-            ) != 0;
-        si
-
         run_grep(pattern: string, in_file: string, out_file: string) -> bool is
             return
                 run(
@@ -341,7 +287,7 @@ namespace Tester is
             environment: Iterable[Pair[string,string]]
         ) -> int
         is
-            let process = start(path, arguments);
+            let process = start(path, arguments, environment);
             
             return wait(process, timeout, out_file, err_file);
         si

--- a/src/test-queue.ghul
+++ b/src/test-queue.ghul
@@ -13,13 +13,12 @@ namespace Tester is
     class TEST_QUEUE is
         _host_cli: string;
         _target_cli: string;
-        _use_installed_compiler: bool;
+        _is_ci: bool;
+        _compiler_under_test: COMPILER_UNDER_TEST;
 
         _task_queue: TASK_QUEUE;
 
         _tests: MutableList[TEST];
-
-        _runtime_path: string;
 
         progress: int;
         count: int => _tests.count;
@@ -28,15 +27,22 @@ namespace Tester is
         pass_count: int => _tests | .filter(t => t.has_passed).count();
         fail_count: int => _tests | .filter(t => t.has_failed).count();
 
-        init(host_cli: string, target_cli: string) is
+        init(
+            host_cli: string, 
+            target_cli: string,
+            is_ci: bool,
+            compiler_under_test: COMPILER_UNDER_TEST)
+        is
             _host_cli = host_cli;
             _target_cli = target_cli;
+            _is_ci = is_ci;
+            _compiler_under_test = compiler_under_test;
 
             let requested_test_processes = System.Environment.get_environment_variable("TEST_PROCESSES");
 
             let actual_test_processes: int;
 
-            _runtime_path = get_runtime_path();
+            // _runtime_path = get_runtime_path();
 
             if requested_test_processes? then
                 actual_test_processes = System.Convert.to_int32(requested_test_processes);                
@@ -65,8 +71,7 @@ namespace Tester is
                     new RUNNER(
                         _host_cli,
                         _target_cli,
-                        _runtime_path,
-                        _use_installed_compiler, 
+                        _compiler_under_test,
                         test
                     );
 
@@ -152,19 +157,5 @@ namespace Tester is
 
                 return path;
             si);   
-
-        get_runtime_path() -> string is
-            let executing_assembly = System.Reflection.Assembly.get_executing_assembly();
-
-            let assembly_path = IO.Path.get_full_path(executing_assembly.location);
-
-            let result = IO.Path.get_directory_name(assembly_path);
-
-            if !result.ends_with('/') then
-                result = result + '/';
-            fi
-
-            return result + "ghul-runtime.dll";
-        si        
     si
 si


### PR DESCRIPTION
- If ${CI} not set, run the compiler from the nearest publish folder