### PR TITLE
Use release version of compiler tool

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -3,7 +3,7 @@
   "isRoot": true,
   "tools": {
     "ghul.compiler": {
-      "version": "0.6.0-alpha.15",
+      "version": "0.6.5",
       "commands": [
         "ghul-compiler"
       ]

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,5 +1,5 @@
 {
-	"image": "ghul/devcontainer:dotnet",
+	"image": "ghcr.io/degory/ghul/devcontainer:dotnet",
 	"containerUser": "vscode",
 	"extensions": [
 		"degory.ghul"

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -22,14 +22,14 @@ env:
 jobs:
   version:
     name: Create a version number
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     timeout-minutes: 1
     outputs:
       tag: ${{ steps.create_version.outputs.tag }}
       package: ${{ steps.create_version.outputs.package }}
-
+      
     permissions:
-      contents: 'write'      
+      contents: 'write'
 
     steps:
     - uses: actions/checkout@v3
@@ -43,7 +43,6 @@ jobs:
         token: ${{ secrets.GITHUB_TOKEN }}
       env:
         PRERELEASE: ${{ github.event_name == 'pull_request' }}
-
 
   build:
     name: Build and publish NuGet package
@@ -74,7 +73,7 @@ jobs:
       run: dotnet pack -p:Version=${{ needs.version.outputs.package }}
 
     - name: Upload .NET package artefact
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v4
       with:
         name: package
         path: nupkg
@@ -103,7 +102,7 @@ jobs:
     - uses: actions/checkout@v3
 
     - name: Download package
-      uses: actions/download-artifact@v2
+      uses: actions/download-artifact@v4
       with:
         name: package
         path: nupkg

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -4,7 +4,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="ghul.targets" Version="1.2.0" />
+    <PackageReference Include="ghul.targets" Version="1.2.1" />
     <PackageReference Include="ghul.pipes" Version="1.0.0" />
     <PackageReference Include="ghul.runtime" Version="1.0.0" />
   </ItemGroup>

--- a/README.md
+++ b/README.md
@@ -6,8 +6,8 @@
 [![Release Date](https://img.shields.io/github/release-date/degory/ghul-test)](https://github.com/degory/ghul-test/releases)
 [![Issues](https://img.shields.io/github/issues/degory/ghul-test)](https://github.com/degory/ghul-test/issues) 
 [![License](https://img.shields.io/github/license/degory/ghul-test)](https://github.com/degory/ghul-test/blob/main/LICENSE)
-[![ghūl](https://img.shields.io/badge/gh%C5%ABl-100%25!-information)](https://ghul.io)
+[![ghūl](https://img.shields.io/badge/gh%C5%ABl-100%25!-information)](https://ghul.dev)
 
-This is a very simple snapshot based test runner which is used by the [ghūl compiler](https://github.com/degory/ghul) [integration tests](https://github.com/degory/ghul/tree/master/integration-tests). It compares test expectations, in the form of snapshot text files, against the actual outputs of the compiler and test executables and flags any differences.
+This is a very simple snapshot based test runner which is used by the [ghūl programming language](https://ghul.dev) [compiler](https://github.com/degory/ghul) [integration tests](https://github.com/degory/ghul/tree/master/integration-tests). It compares test expectations, in the form of snapshot text files, against the actual outputs of the compiler and test executables and flags any differences.
 
 

--- a/ghul-test.ghulproj
+++ b/ghul-test.ghulproj
@@ -16,7 +16,7 @@
 
     <PackageId>ghul.test</PackageId>
     <Authors>degory</Authors>
-    <Company>ghul.io</Company>
+    <Company>ghul.dev</Company>
 
     <PackageOutputPath>./nupkg</PackageOutputPath>
     <IsTool>true</IsTool>

--- a/integration-tests/execution-fail/hello-world/ghul.json
+++ b/integration-tests/execution-fail/hello-world/ghul.json
@@ -1,5 +1,5 @@
 {
-    "compiler": "../../../bin/Debug/net6.0/ghul",
+    "compiler": "../../../bin/Release/net8.0/ghul",
     "source": [
         "."
     ]

--- a/integration-tests/execution-pass/hello-world/ghul.json
+++ b/integration-tests/execution-pass/hello-world/ghul.json
@@ -1,5 +1,5 @@
 {
-    "compiler": "../../../bin/Debug/net6.0/ghul",
+    "compiler": "../../../bin/Release/net8.0/ghul",
     "source": [
         "."
     ]


### PR DESCRIPTION
- Update from an alpha version of the compler to the latest stable release, now .NET 8 support is merged
- Use latest ghul.targets
- Update website URLs to reference https://ghul.dev
- Update devcontainer image to reference GHCR
- Use latest versions of upload and download asset actions in pipeline
- Fix incorrect integration test ghul.json compiler binary paths