### PR TITLE
Fix issues running on Windows

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -3,7 +3,7 @@
   "isRoot": true,
   "tools": {
     "ghul.compiler": {
-      "version": "0.6.13",
+      "version": "0.6.14",
       "commands": [
         "ghul-compiler"
       ]

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,6 +1,6 @@
 <Project>
   <PropertyGroup>
-    <Version>1.1.2-alpha.1</Version>
+    <Version>1.1.3-alpha.5</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/integration-tests/execution-fail/hello-world/.vscode/tasks.json
+++ b/integration-tests/execution-fail/hello-world/.vscode/tasks.json
@@ -3,16 +3,21 @@
     "tasks": [
         {
             "label": "Run test",
-            "command": "dotnet ghul-test ${workspaceFolder}",
+            "command": "dotnet ghul-test \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "test",
                 "isDefault": true
+            },
+            "options": {
+                "env": {
+                    "CI": "1"
+                }
             }
         },
         {
             "label": "Capture test expectation",
-            "command": "../../../tasks/capture.sh ${workspaceFolder}",
+            "command": "../../../tasks/capture.sh \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "build",

--- a/integration-tests/execution-pass/hello-world/.vscode/tasks.json
+++ b/integration-tests/execution-pass/hello-world/.vscode/tasks.json
@@ -3,16 +3,21 @@
     "tasks": [
         {
             "label": "Run test",
-            "command": "dotnet ghul-test ${workspaceFolder}",
+            "command": "dotnet ghul-test \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "test",
                 "isDefault": true
+            },
+            "options": {
+                "env": {
+                    "CI": "1"
+                }
             }
         },
         {
             "label": "Capture test expectation",
-            "command": "../../../tasks/capture.sh ${workspaceFolder}",
+            "command": "../../../tasks/capture.sh \"${workspaceFolder}\"",
             "type": "shell",
             "group": {
                 "kind": "build",

--- a/src/runner.ghul
+++ b/src/runner.ghul
@@ -201,8 +201,8 @@ namespace Tester is
         run_grep(pattern: string, in_file: string, out_file: string) -> bool is
             return
                 run(
-                    "fgrep",
-                    [pattern, in_file],
+                    "grep",
+                    ["-F", pattern, in_file],
                     5000,
                     out_file,
                     null,
@@ -322,7 +322,7 @@ namespace Tester is
                             arg.replace("\\", "\\\\").replace("\"", "\"\""))
                         .to_string(" ");
             fi
-            
+
             start_info.working_directory = _test.path;
 
             start_info.redirect_standard_output = true;

--- a/src/test-queue.ghul
+++ b/src/test-queue.ghul
@@ -148,14 +148,7 @@ namespace Tester is
         si
 
         get_source_files(path: string) -> Iterable[string] =>
-            Directory.get_files(path, "*.ghul") | .map(path: string is
-                let last_slash_index = path.last_index_of('/');
-
-                if last_slash_index > 0 then
-                    return path.substring(last_slash_index + 1);
-                fi
-
-                return path;
-            si);   
+            Directory.get_files(path, "*.ghul") | 
+                .map(path: string => Path.get_file_name(path));
     si
 si

--- a/tests/src/runner.ghul
+++ b/tests/src/runner.ghul
@@ -1,0 +1,168 @@
+namespace Tests is
+    use Collections;
+    use IO;
+
+    use Microsoft.VisualStudio.TestTools.UnitTesting.Assert;
+    use NSubstitute;
+    use NSubstitute.SubstituteExtensions.returns;
+
+    use Tester;
+    
+    class RUNNER_Should is
+        @test()
+
+        init() is si
+
+        get_private_instance_field(from: object, name: string) -> object is
+            let non_public = cast int(System.Reflection.BindingFlags.NON_PUBLIC);
+            let instance = cast int(System.Reflection.BindingFlags.INSTANCE);
+            let binding_flags = cast System.Reflection.BindingFlags(non_public + instance); 
+
+            let field = 
+                from.get_type().get_field(
+                    name,
+                    binding_flags
+                );
+
+            return field.get_value(from);
+        si
+
+        set_private_instance_field(from: object, name: string, value: object) is
+            let non_public = cast int(System.Reflection.BindingFlags.NON_PUBLIC);
+            let instance = cast int(System.Reflection.BindingFlags.INSTANCE);
+            let binding_flags = cast System.Reflection.BindingFlags(non_public + instance); 
+
+            let field = 
+                from.get_type().get_field(
+                    name,
+                    binding_flags
+                );
+
+            field.set_value(from, value);
+        si
+
+        get_private_static_field(from: object, name: string) -> object is
+            let non_public = cast int(System.Reflection.BindingFlags.NON_PUBLIC);
+            let instance = cast int(System.Reflection.BindingFlags.STATIC);
+            let binding_flags = cast System.Reflection.BindingFlags(non_public + instance); 
+
+            let field = 
+                from.get_type().get_field(
+                    name,
+                    binding_flags
+                );
+
+            return field.get_value(null);
+        si
+
+        get_mock_COMPILER_UNDER_TEST() -> COMPILER_UNDER_TEST is
+            return NSubstitute.Substitute.`for`[COMPILER_UNDER_TEST]([false]:object);
+        si
+
+        get_mock_TEST() -> TEST is
+            return NSubstitute.Substitute.`for`[TEST]([
+                "path/to/test",  // : string, 
+                ["file_1.ghul", "file_2.ghul"], // : Iterable[string],
+                "--stuff", // : string,
+                false // : bool        
+            ]);
+        si
+        
+        get_mock_FAILURE() -> FAILURE is
+            return NSubstitute.Substitute.`for`[FAILURE]([
+                get_mock_TEST(),
+                "this is a message",
+                "and this is additional detail"
+            ]);
+        si
+
+        get_real_FAILURE() -> FAILURE is
+            return new FAILURE(
+                get_mock_TEST(),
+                "this is a message",
+                "and this is additional detail"
+            );
+        si
+
+        RUNNER__init__given_no_collate_environment__creates_collate_environment_of_correct_map_type() is
+            @test()
+
+            let arguments = System.Array.empty`[object]();
+
+            let compiler_under_test = get_mock_COMPILER_UNDER_TEST();
+            let test = get_mock_TEST();
+
+            let runner = new RUNNER("dotnet", "dotnet", compiler_under_test, test);
+
+            // get the private static field _collate_environment:
+            let field_value = 
+                get_private_static_field(
+                    runner, 
+                    "_collate_environment"
+                );
+
+            Std.error.write_line("field_value: " + field_value);
+
+            if field_value? then
+                Std.error.write_line("field_value type: " + field_value.get_type().to_string());
+            fi
+
+            should(isa Map[string,string](field_value)).be_true(null, null);
+        si
+
+        RUNNER__init__given_no_collate_environment__adds_LC_COLLATE_key_with_value_C() is
+            @test()
+
+            let arguments = System.Array.empty`[object]();
+
+            let compiler_under_test = get_mock_COMPILER_UNDER_TEST();
+            let test = get_mock_TEST();
+
+            let runner = new RUNNER("dotnet", "dotnet", compiler_under_test, test);
+
+            // get the private static field _collate_environment:
+            let field_value = 
+                get_private_static_field(
+                    runner, 
+                    "_collate_environment"
+                );
+
+            let collate_as_map = cast MutableMap[string,string](field_value);
+
+            should(collate_as_map.contains_key("LC_COLLATE")).be_true(null, null);
+            should(collate_as_map["LC_COLLATE"]).be("C", null, null);
+        si
+
+        RUNNER__get_result__given_failure__returns_failure() is
+            @test()
+
+            let arguments = System.Array.empty`[object]();
+
+            let compiler_under_test = get_mock_COMPILER_UNDER_TEST();
+            let test = get_mock_TEST();
+            let runner = new RUNNER("dotnet", "dotnet", compiler_under_test, test);
+
+            let failure = get_real_FAILURE();
+
+            set_private_instance_field(runner, "_failure", failure);
+
+            let result = runner.get_result();
+
+            should(result).be(failure, null, null);
+        si
+
+        RUNNER__get_result__given_no_failure__returns_PASS() is
+            @test()
+
+            let arguments = System.Array.empty`[object]();
+
+            let compiler_under_test = get_mock_COMPILER_UNDER_TEST();
+            let test = get_mock_TEST();
+            let runner = new RUNNER("dotnet", "dotnet", compiler_under_test, test);
+
+            let result = runner.get_result();
+
+            should(isa PASS(result)).be_true(null, null);
+        si
+    si
+si

--- a/tests/tests.ghulproj
+++ b/tests/tests.ghulproj
@@ -12,6 +12,7 @@
     <PackageReference Include="MSTest.TestAdapter" Version="3.2.0" />
     <PackageReference Include="MSTest.TestFramework" Version="3.2.0" />
     <PackageReference Include="FluentAssertions" Version="6.12.0" />
+    <PackageReference Include="NSubstitute" Version="5.1.0" />
     
     <ProjectReference Include="../ghul-test.ghulproj" />
 


### PR DESCRIPTION
- Use `grep -F` rather than `fgrep` for compatibility with Git for Windows MSYS2, where `fgrep` is a script.
- Fix issue where paths on Windows were wrongly constructed, causing the compiler not to find source files.