### PR TITLE
Add support for building tests with `dotnet build`

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -3,7 +3,7 @@
   "isRoot": true,
   "tools": {
     "ghul.compiler": {
-      "version": "0.6.15",
+      "version": "0.6.16",
       "commands": [
         "ghul-compiler"
       ]

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,11 +1,11 @@
 <Project>
   <PropertyGroup>
-    <Version>1.1.3-alpha.5</Version>
+    <Version>1.1.4-alpha.41</Version>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="ghul.targets" Version="1.2.2" />
-    <PackageReference Include="ghul.pipes" Version="1.1.1" />
-    <PackageReference Include="ghul.runtime" Version="1.1.1" />
+    <PackageReference Include="ghul.targets" Version="1.2.*" />
+    <PackageReference Include="ghul.pipes" Version="1.1.*" />
+    <PackageReference Include="ghul.runtime" Version="1.1.*" />
   </ItemGroup>
 </Project>

--- a/README.md
+++ b/README.md
@@ -10,4 +10,3 @@
 
 This is a very simple snapshot based test runner which is used by the [ghūl programming language](https://ghul.dev) [compiler](https://github.com/degory/ghul) [integration tests](https://github.com/degory/ghul/tree/master/integration-tests). It compares test expectations, in the form of snapshot text files, against the actual outputs of the compiler and test executables and flags any differences.
 
-

--- a/src/compiler-under-test.ghul
+++ b/src/compiler-under-test.ghul
@@ -8,34 +8,39 @@ namespace Tester is
     use Collections.Iterable;
     use Collections.LIST;
 
+    enum COMPILER_RUN_MODE is
+        CI,
+        LOCAL,
+        DOTNET
+    si
+
     class COMPILER_UNDER_TEST is
-        _is_ci: bool;
+        _run_mode: COMPILER_RUN_MODE;
         _publish: string;
         _executable: string;
         _runtime_path: string;
         _arguments: Iterable[string];
+        _use_dotnet: bool;
 
-        init(is_ci: bool) is
-            _is_ci = is_ci;
+        init(run_mode: COMPILER_RUN_MODE) is
+            _run_mode = run_mode;
 
-            if _is_ci then
-                IO.Std.error.write_line("CI is set: expect compiler to be installed as a local tool");
-
+            if _run_mode == COMPILER_RUN_MODE.DOTNET then
+                _executable = "dotnet";
+                _arguments = ["build"];
+            elif _run_mode == COMPILER_RUN_MODE.CI then
                 _executable = "dotnet";
                 _runtime_path = get_ghul_test_runtime_path();
                 _arguments = ["ghul-compiler", "--v3", "--test-run"];
-            else
-                IO.Std.error.write_line("CI is not set: expect compiler to be published in ./publish");
-
+            elif _run_mode == COMPILER_RUN_MODE.LOCAL then
                 _publish = find_publish_directory();
 
                 _executable = find_published_compiler();
                 _runtime_path = get_published_compiler_path("ghul-runtime.dll");
                 _arguments = ["--v3", "--test-run"];
+            else
+                throw new Exception("unknown run mode: " + _run_mode);
             fi
-
-            IO.Std.error.write_line("compiler: " + [_executable] | .cat(_arguments) );
-            IO.Std.error.write_line("runtime: " + _runtime_path);
         si
         
         run_compiler(runner: RUNNER, test: TEST) -> bool is
@@ -48,18 +53,29 @@ namespace Tester is
                     test.flags.split([' ']) | .map((flag) -> string => flag.trim())
                 );
             fi
-            
-            arguments.add_range(test.source_files);
 
-            arguments.add_range(["-o", "binary.exe"]);                
-            
-            let result = runner.run(
-                _executable,
-                arguments,
-                5000,
-                null,
-                "compiler.out"
-            );
+            let result = -1;
+
+            if _run_mode == COMPILER_RUN_MODE.DOTNET then
+                result = runner.run(
+                    _executable,
+                    arguments,
+                    5000,
+                    "compiler.out", // MSBuild coerces stderr output to stdout
+                    null
+                );
+            else
+                arguments.add_range(test.source_files);
+                arguments.add_range(["-o", "binary.exe"]);
+
+                result = runner.run(
+                    _executable,
+                    arguments,
+                    5000,
+                    null,
+                    "compiler.out"
+                );
+            fi
 
             if !File.exists(runner.get_path("compiler.out")) then
                 throw new Exception("compiler output file not found");
@@ -69,14 +85,35 @@ namespace Tester is
                 return false;
             fi
 
-            if !runner.read_all_text("compiler.out").contains("*** succeeded ***") then
+            if _run_mode != COMPILER_RUN_MODE.DOTNET /\ !runner.read_all_text("compiler.out").contains("*** succeeded ***") then
                 throw new Exception("compiler success exit status but success message not found in output");
             fi
 
-            return File.exists(runner.get_path("binary.exe"));
+            // FIXME: this is a bit convoluted:
+            return File.exists(get_binary_path(runner));
+        si
+
+        get_binary_path_relative_to_test_folder(runner: RUNNER) -> string is
+            if _run_mode == COMPILER_RUN_MODE.DOTNET then
+                return Path.join(["bin", "Debug", "net8.0", "binary.dll"]);
+            fi
+
+            return "binary.exe";
+        si
+
+        get_binary_path(runner: RUNNER) -> string is
+            if _run_mode == COMPILER_RUN_MODE.DOTNET then
+                return Path.join([runner.get_path(), "bin", "Debug", "net8.0", "binary.dll"]);
+            fi
+
+            return runner.get_path("binary.exe");
         si
 
         run_ln_runtime(runner: RUNNER) -> bool is
+            if _run_mode == COMPILER_RUN_MODE.DOTNET then
+                return true;
+            fi
+
             return runner.run(
                 "ln",
                 ["-s", _runtime_path, "."],

--- a/src/main.ghul
+++ b/src/main.ghul
@@ -29,15 +29,27 @@ namespace Tester is
             let ci_string = 
                 System.Environment.get_environment_variable("CI");
 
-            let is_ci =
+            let run_mode = COMPILER_RUN_MODE.LOCAL;
+
+            if 
                 !string.is_null_or_white_space(ci_string) /\
-                (ci_string =~ "1" \/ ci_string.to_lower() =~ "true");
+                (ci_string =~ "1" \/ ci_string.to_lower() =~ "true")
+            then
+                run_mode = COMPILER_RUN_MODE.CI;
+            fi
 
-            let compiler_under_test = new COMPILER_UNDER_TEST(is_ci);
+            let arguments_to_skip = 0;
 
-            let queue = new TEST_QUEUE(host, target, is_ci, compiler_under_test);
+            if arguments.count > 1 /\ arguments[0] =~ "--use-dotnet-build" then
+                run_mode = COMPILER_RUN_MODE.DOTNET;
+                arguments_to_skip = 1;
+            fi
+            
+            let compiler_under_test = new COMPILER_UNDER_TEST(run_mode);
 
-            for path in arguments do
+            let queue = new TEST_QUEUE(host, target, compiler_under_test);
+
+            for path in arguments | .skip(arguments_to_skip) do
                 if !Directory.exists(path) then
                     Std.write_line("not a directory: " + path);
                     return 1;

--- a/src/runner.ghul
+++ b/src/runner.ghul
@@ -90,27 +90,29 @@ namespace Tester is
 
             let build_succeeded = _compiler_under_test.run_compiler(self, _test);
 
+            let exit_after_grep_and_sort = false;
+
             if build_succeeded then
                 if _test.is_build_fail_expected then
                     add_fail("unexpected build success: " + _test.path);
-
-                    return;
+                    exit_after_grep_and_sort = true;
                 fi
             else
                 if !_test.is_build_fail_expected then
                     add_fail("unexpected build failure", "compiler.out");
-
-                    return;
+                    exit_after_grep_and_sort = true;
                 fi
             fi
 
             run_grep("error:", "compiler.out", "err.grep");
-                 
             run_grep("warn:", "compiler.out", "warn.grep");
 
             run_sort("err.grep", "err.sort");
-
             run_sort("warn.grep", "warn.sort");
+
+            if exit_after_grep_and_sort then
+                return;
+            fi
 
             run_diff("errors", "err.expected", "err.sort", "err.diff", true);
 
@@ -157,7 +159,9 @@ namespace Tester is
         si
         
         run_binary() -> bool is
-            let binary_path = get_path("binary.exe");
+            // this needs to be a path relative to the directory
+            // that ghul-test was run from
+            let binary_path = _compiler_under_test.get_binary_path(self);
 
             if !File.exists(binary_path) then
                 add_fail("no binary found: " + binary_path);
@@ -167,7 +171,9 @@ namespace Tester is
             let exit_status =
                 run(
                     _target_cli,
-                    ["binary.exe"],
+                    // but this needs to be a path relative to the directory
+                    // that the test is in
+                    [_compiler_under_test.get_binary_path_relative_to_test_folder(self)],
                     5000,
                     "run.out",
                     "run.err"
@@ -214,12 +220,12 @@ namespace Tester is
             return
                 run(
                     "sort",
-                    [in_file, "--output=" + out_file],
+                    [in_file],
                     5000,
-                    null,
+                    out_file,
                     null,
                     _collate_environment
-                ) != 0;            
+                ) != 0;
         si
         
         run_diff(
@@ -251,7 +257,7 @@ namespace Tester is
             if ignore_space_changes then
                 args = ["-b", "--strip-trailing-cr", expected_file_name, actual_file_name];
             else
-                args = [expected_file_name, actual_file_name];
+                args = ["--strip-trailing-cr", expected_file_name, actual_file_name];
             fi
 
             let result = run(
@@ -308,18 +314,17 @@ namespace Tester is
                 od                        
             fi
 
-            // FIXME: StartInfo.arguments_list is broken:
-            // for arg in arguments do
-            //     start_info.argument_list.add(arg);                
-            // od
-
             let arguments_string = new StringBuilder();
 
-            if arguments? then
+            if arguments? then                
                 start_info.arguments =
                     arguments |
+                        .filter(a => a?)
                         .map(arg => 
-                            arg.replace("\\", "\\\\").replace("\"", "\"\""))
+                            arg
+                                // FIXME: not convinced either of these are necessary
+                                .replace("\\", "\\\\")
+                                .replace("\"", "\"\""))
                         .to_string(" ");
             fi
 
@@ -332,7 +337,7 @@ namespace Tester is
             let result = Process.start(start_info);
 
             if result == null then
-                throw new Exception("failed to start process: " + path + " " + arguments| .to_string(" "));
+                throw new Exception("failed to start process: " + path + " " + start_info.arguments);
             fi
             
             return result;
@@ -397,7 +402,10 @@ namespace Tester is
         si
         
         get_path(file_name: string) -> string =>
-            _test.path + "/" + file_name;
+            IO.Path.join(_test.path, file_name);
+
+        get_path() -> string =>
+            _test.path;
 
         write_all_text(file_name: string, text: string) is
             File.write_all_text(get_path(file_name), text);

--- a/src/test-queue.ghul
+++ b/src/test-queue.ghul
@@ -13,7 +13,6 @@ namespace Tester is
     class TEST_QUEUE is
         _host_cli: string;
         _target_cli: string;
-        _is_ci: bool;
         _compiler_under_test: COMPILER_UNDER_TEST;
 
         _task_queue: TASK_QUEUE;
@@ -30,19 +29,15 @@ namespace Tester is
         init(
             host_cli: string, 
             target_cli: string,
-            is_ci: bool,
             compiler_under_test: COMPILER_UNDER_TEST)
         is
             _host_cli = host_cli;
             _target_cli = target_cli;
-            _is_ci = is_ci;
             _compiler_under_test = compiler_under_test;
 
             let requested_test_processes = System.Environment.get_environment_variable("TEST_PROCESSES");
 
             let actual_test_processes: int;
-
-            // _runtime_path = get_runtime_path();
 
             if requested_test_processes? then
                 actual_test_processes = System.Convert.to_int32(requested_test_processes);                

--- a/tests/src/runner.ghul
+++ b/tests/src/runner.ghul
@@ -55,8 +55,8 @@ namespace Tests is
             return field.get_value(null);
         si
 
-        get_mock_COMPILER_UNDER_TEST() -> COMPILER_UNDER_TEST is
-            return NSubstitute.Substitute.`for`[COMPILER_UNDER_TEST]([false]:object);
+        get_mock_COMPILER_UNDER_TEST(run_mode: COMPILER_RUN_MODE) -> COMPILER_UNDER_TEST is
+            return NSubstitute.Substitute.`for`[COMPILER_UNDER_TEST]([run_mode]:object);
         si
 
         get_mock_TEST() -> TEST is
@@ -89,7 +89,7 @@ namespace Tests is
 
             let arguments = System.Array.empty`[object]();
 
-            let compiler_under_test = get_mock_COMPILER_UNDER_TEST();
+            let compiler_under_test = get_mock_COMPILER_UNDER_TEST(COMPILER_RUN_MODE.CI);
             let test = get_mock_TEST();
 
             let runner = new RUNNER("dotnet", "dotnet", compiler_under_test, test);
@@ -115,7 +115,7 @@ namespace Tests is
 
             let arguments = System.Array.empty`[object]();
 
-            let compiler_under_test = get_mock_COMPILER_UNDER_TEST();
+            let compiler_under_test = get_mock_COMPILER_UNDER_TEST(COMPILER_RUN_MODE.DOTNET);
             let test = get_mock_TEST();
 
             let runner = new RUNNER("dotnet", "dotnet", compiler_under_test, test);
@@ -138,7 +138,7 @@ namespace Tests is
 
             let arguments = System.Array.empty`[object]();
 
-            let compiler_under_test = get_mock_COMPILER_UNDER_TEST();
+            let compiler_under_test = get_mock_COMPILER_UNDER_TEST(COMPILER_RUN_MODE.LOCAL);
             let test = get_mock_TEST();
             let runner = new RUNNER("dotnet", "dotnet", compiler_under_test, test);
 
@@ -156,7 +156,7 @@ namespace Tests is
 
             let arguments = System.Array.empty`[object]();
 
-            let compiler_under_test = get_mock_COMPILER_UNDER_TEST();
+            let compiler_under_test = get_mock_COMPILER_UNDER_TEST(COMPILER_RUN_MODE.CI);
             let test = get_mock_TEST();
             let runner = new RUNNER("dotnet", "dotnet", compiler_under_test, test);
 


### PR DESCRIPTION
- Add a command line option `--use-dotnet-build`, to support tests that have additional dependencies or otherwise need the MSbuild build process