### PR TITLE
Update to latest runtime

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -3,7 +3,7 @@
   "isRoot": true,
   "tools": {
     "ghul.compiler": {
-      "version": "0.7.0",
+      "version": "0.7.1",
       "commands": [
         "ghul-compiler"
       ]

--- a/.dependabot/ghul-test.csproj
+++ b/.dependabot/ghul-test.csproj
@@ -1,3 +1,11 @@
+<!--
+    Ensure Dependabot is triggered for this repository as
+    it doesn't recognize .ghulproj as a valid project file
+-->
+
 <Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="../ghul-test.ghulproj" />
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net8.0</TargetFramework>
+  </PropertyGroup>
 </Project>

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,7 +4,7 @@ updates:
     directory: ".dependabot/"
     schedule:
       interval: "daily"
-  - package-ecosystem: "nuget"
-    directory: "tests/.dependabot/"
-    schedule:
-      interval: "daily"
+    allow:
+      - dependency-type: "all"
+    ignore:
+      - dependency-name: "ghul.compiler"

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,11 +1,10 @@
 <Project>
   <PropertyGroup>
-    <Version>1.1.4-alpha.41</Version>
+    <Version>1.2.1-alpha.1</Version>
+    <NoWarn>$(NoWarn);NU1507</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="ghul.targets" Version="1.2.*" />
-    <PackageReference Include="ghul.pipes" Version="1.1.*" />
-    <PackageReference Include="ghul.runtime" Version="1.2.*" />
+    <PackageReference Include="ghul.runtime" />
   </ItemGroup>
 </Project>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -1,0 +1,22 @@
+<Project>
+  <ItemGroup>
+    <!-- ghūl runtime -->
+    <PackageVersion Include="ghul.runtime" Version="1.3.0" />
+
+    <!-- ghūl compiler dependencies -->
+    <PackageVersion Include="System.Reflection.MetadataLoadContext" Version="8.0.0" />
+    <PackageVersion Include="runtime.linux-x64.Microsoft.NETCore.ILAsm" Version="8.0.0" />
+    <PackageVersion Include="runtime.win-x64.Microsoft.NETCore.ILAsm" Version="8.0.0" />
+
+    <!-- unit test dependencies -->
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
+    <PackageVersion Include="Moq" Version="4.20.70" />
+    <PackageVersion Include="MSTest.TestAdapter" Version="3.2.0" />
+    <PackageVersion Include="MSTest.TestFramework" Version="3.2.0" />
+    <PackageVersion Include="FluentAssertions" Version="6.12.0" />
+    <PackageVersion Include="NSubstitute" Version="5.1.0" />
+
+    <!-- common dependencies -->
+    <PackageVersion Include="System.IO.Abstractions" Version="20.0.15" />
+  </ItemGroup>
+</Project>

--- a/ghul-test.ghulproj
+++ b/ghul-test.ghulproj
@@ -2,6 +2,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>net8.0</TargetFramework>
+    <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
 
     <Title>ghūl test</Title>
     <PackageDescription>ghūl compiler snapshot test runner</PackageDescription>

--- a/tests/.dependabot/tests.csproj
+++ b/tests/.dependabot/tests.csproj
@@ -1,3 +1,0 @@
-<Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="../tests.ghulproj" />
-</Project>

--- a/tests/tests.ghulproj
+++ b/tests/tests.ghulproj
@@ -5,14 +5,16 @@
     <DebugType>None</DebugType>
     <GhulCompiler>dotnet ghul-compiler</GhulCompiler>
     <EnableDefaultCompileItems>false</EnableDefaultCompileItems>
+
+    <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
-    <PackageReference Include="MSTest.TestAdapter" Version="3.2.0" />
-    <PackageReference Include="MSTest.TestFramework" Version="3.2.0" />
-    <PackageReference Include="FluentAssertions" Version="6.12.0" />
-    <PackageReference Include="NSubstitute" Version="5.1.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="MSTest.TestAdapter" />
+    <PackageReference Include="MSTest.TestFramework" />
+    <PackageReference Include="FluentAssertions" />
+    <PackageReference Include="NSubstitute" />
     
     <ProjectReference Include="../ghul-test.ghulproj" />
 


### PR DESCRIPTION
- Bump runtime library to version that integrates the ghūl MSBuild targets
- Bump compiler tool to latest
- Use Directory.Packages.props for central package version management
- Switch to a single Dependabot config across the main project and the two test projects

Bumps #minor version