### PR TITLE
Allow integration tests to override the runtime DLL location

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,16 +47,18 @@ Any mismatches cause a failure report containing a unified diff of the actual ve
 ## Command Line Usage
 
 ```text
-ghul-test [--use-dotnet-build] <test-folder> [...]
+ghul-test [--use-dotnet-build] [--runtime-dll <path>] <test-folder> [...]
 ```
 
 - `--use-dotnet-build` – expects each test folder to be an MSBuild project. For ghūl projects the file should end with `.ghulproj`. The runner builds the project with `dotnet build` instead of invoking the compiler directly.
+- `--runtime-dll <path>` – use the supplied `ghul-runtime.dll` for compiled test binaries instead of the version that ships with `ghul-test`. The path must point to an existing file. Takes precedence over the `GHUL_RUNTIME_DLL` environment variable. Has no effect under `--use-dotnet-build`, which resolves the runtime via the test project's own `PackageReference`.
 - `<test-folder>` – one or more directories containing tests. Each is recursively searched for subdirectories with a `ghulflags` file if not using `--use-dotnet-build`.
 
 Environment variables influence behaviour:
 
 - `HOST` and `TARGET` – specify the CLI used to run the compiler and the compiled binary (default `dotnet`).
-- `CI` – when set to `1` or `true`, enables CI mode. In this mode `ghul-runtime.dll` is taken from the test runner’s own location.
+- `CI` – when set to `1` or `true`, enables CI mode. In this mode `ghul-runtime.dll` is taken from the test runner's own location unless overridden by `--runtime-dll` / `GHUL_RUNTIME_DLL`.
+- `GHUL_RUNTIME_DLL` – path to a `ghul-runtime.dll` to use for compiled test binaries, overriding the version that ships with `ghul-test`. Equivalent to passing `--runtime-dll`; the CLI flag wins if both are set.
 - `TEST_PROCESSES` – number of worker processes to use. If unset, a value derived from CPU count is used.
 
 The runner prints progress for each test and a final summary indicating total, enabled, passed and failed counts.
@@ -64,6 +66,8 @@ The runner prints progress for each test and a final summary indicating total, e
 ## Runtime Library Handling
 
 When the compiler is invoked directly (the default and CI modes), the produced executable expects to find `ghul-runtime.dll` beside it. The runner therefore creates a symbolic link in the test directory pointing to the runtime library. This link is not needed when `--use-dotnet-build` is used. After the test completes successfully, the link is deleted during cleanup.
+
+By default the runtime DLL is sourced from the published compiler's directory (LOCAL mode) or the test runner's own install directory (CI mode). When the integration tests need to run against a runtime version other than the one `ghul-test` itself was packaged with — for example, when CI builds a compiler that depends on a newer `ghul.runtime` than the pinned `ghul.test` ships with — pass `--runtime-dll <path>` or set `GHUL_RUNTIME_DLL` to override the discovered location with an explicit DLL path.
 
 ## MSBuild Projects
 

--- a/integration-tests/run-integration-tests.sh
+++ b/integration-tests/run-integration-tests.sh
@@ -47,4 +47,53 @@ fi
 
 echo integration-tests/execution-pass: PASS
 
+
+echo integration-tests/runtime-dll-override-valid...
+
+# The --runtime-dll override should be transparent when pointed at the same
+# runtime that CI mode would have discovered itself: hello-world still passes.
+RUNTIME_DLL="$(pwd)/bin/Debug/net8.0/ghul-runtime.dll"
+
+if [ ! -f "$RUNTIME_DLL" ]; then
+    echo "expected runtime DLL not found at $RUNTIME_DLL"
+    exit 1
+fi
+
+TEST_PROCESSES=1 CI=1 dotnet run -- --runtime-dll "$RUNTIME_DLL" integration-tests/execution-pass | tee actual-output
+
+if [ "${PIPESTATUS[0]}" != "0" ]; then
+    echo integration-tests/runtime-dll-override-valid unexpectedly failed
+
+    exit 1
+fi
+
+if ! diff integration-tests/execution-pass/expected-output actual-output ; then
+    echo integration-tests/runtime-dll-override-valid output did not match expected output
+
+    exit 1
+fi
+
+echo integration-tests/runtime-dll-override-valid: PASS
+
+
+echo integration-tests/runtime-dll-override-missing...
+
+# A missing runtime DLL must fail fast with a clear message, not silently fall
+# back to default discovery.
+TEST_PROCESSES=1 CI=1 dotnet run -- --runtime-dll /tmp/ghul-test-no-such-runtime.dll integration-tests/execution-pass | tee actual-output
+
+if [ "${PIPESTATUS[0]}" != "1" ]; then
+    echo integration-tests/runtime-dll-override-missing did not exit 1
+
+    exit 1
+fi
+
+if ! grep -q "runtime DLL not found" actual-output ; then
+    echo integration-tests/runtime-dll-override-missing did not report missing-DLL error
+
+    exit 1
+fi
+
+echo integration-tests/runtime-dll-override-missing: PASS
+
 exit 0

--- a/src/compiler-under-test.ghul
+++ b/src/compiler-under-test.ghul
@@ -42,6 +42,20 @@ namespace Tester is
                 throw new Exception("unknown run mode: " + _run_mode);
             fi
         si
+
+        runtime_path: string => _runtime_path;
+
+        set_runtime_path(path: string) is
+            if string.is_null_or_white_space(path) then
+                return;
+            fi
+
+            if !File.exists(path) then
+                throw new Exception("runtime DLL not found: " + path);
+            fi
+
+            _runtime_path = Path.get_full_path(path);
+        si
         
         run_compiler(runner: RUNNER, test: TEST) -> bool is
             let arguments = new LIST[string]();

--- a/src/main.ghul
+++ b/src/main.ghul
@@ -38,23 +38,50 @@ namespace Tester is
                 run_mode = COMPILER_RUN_MODE.CI;
             fi
 
-            let arguments_to_skip = 0;
+            let runtime_dll_override =
+                System.Environment.get_environment_variable("GHUL_RUNTIME_DLL");
 
-            if arguments.count > 1 /\ arguments[0] =~ "--use-dotnet-build" then
-                run_mode = COMPILER_RUN_MODE.DOTNET;
-                arguments_to_skip = 1;
-            fi
-            
+            let test_paths = new LIST[string]();
+
+            let i = 0;
+            while i < arguments.count do
+                let arg = arguments[i];
+
+                if arg =~ "--use-dotnet-build" then
+                    run_mode = COMPILER_RUN_MODE.DOTNET;
+                elif arg =~ "--runtime-dll" then
+                    i = i + 1;
+
+                    if i >= arguments.count then
+                        Std.write_line("--runtime-dll requires a path argument");
+                        return 1;
+                    fi
+
+                    runtime_dll_override = arguments[i];
+                else
+                    test_paths.add(arg);
+                fi
+
+                i = i + 1;
+            od
+
             let compiler_under_test = new COMPILER_UNDER_TEST(run_mode);
+
+            try
+                compiler_under_test.set_runtime_path(runtime_dll_override);
+            catch ex: Exception
+                Std.write_line(ex.message);
+                return 1;
+            yrt
 
             let queue = new TEST_QUEUE(host, target, compiler_under_test);
 
-            for path in arguments | .skip(arguments_to_skip) do
+            for path in test_paths do
                 if !Directory.exists(path) then
                     Std.write_line("not a directory: " + path);
                     return 1;
                 fi
-                
+
                 queue.try_queue_tests(path);
             od
 

--- a/tests/src/compiler-under-test.ghul
+++ b/tests/src/compiler-under-test.ghul
@@ -1,0 +1,78 @@
+namespace Tests is
+    use System.Exception;
+    use System.Reflection.Assembly;
+
+    use IO.Path;
+
+    use Tester;
+
+    class COMPILER_UNDER_TEST_Should is
+        @test()
+
+        init() is si
+
+        get_existing_file_path() -> string is
+            // The current test assembly is guaranteed to exist on disk.
+            return Path.get_full_path(Assembly.get_executing_assembly().location);
+        si
+
+        COMPILER_UNDER_TEST__set_runtime_path__given_null__leaves_runtime_path_unchanged() is
+            @test()
+
+            let cut = new COMPILER_UNDER_TEST(COMPILER_RUN_MODE.CI);
+            let original = cut.runtime_path;
+
+            cut.set_runtime_path(null);
+
+            should(cut.runtime_path).be(original, null, null);
+        si
+
+        COMPILER_UNDER_TEST__set_runtime_path__given_empty_string__leaves_runtime_path_unchanged() is
+            @test()
+
+            let cut = new COMPILER_UNDER_TEST(COMPILER_RUN_MODE.CI);
+            let original = cut.runtime_path;
+
+            cut.set_runtime_path("");
+
+            should(cut.runtime_path).be(original, null, null);
+        si
+
+        COMPILER_UNDER_TEST__set_runtime_path__given_whitespace_only__leaves_runtime_path_unchanged() is
+            @test()
+
+            let cut = new COMPILER_UNDER_TEST(COMPILER_RUN_MODE.CI);
+            let original = cut.runtime_path;
+
+            cut.set_runtime_path("   ");
+
+            should(cut.runtime_path).be(original, null, null);
+        si
+
+        COMPILER_UNDER_TEST__set_runtime_path__given_existing_path__overrides_runtime_path() is
+            @test()
+
+            let cut = new COMPILER_UNDER_TEST(COMPILER_RUN_MODE.CI);
+            let new_path = get_existing_file_path();
+
+            cut.set_runtime_path(new_path);
+
+            should(cut.runtime_path).be(new_path, null, null);
+        si
+
+        COMPILER_UNDER_TEST__set_runtime_path__given_nonexistent_path__throws() is
+            @test()
+
+            let cut = new COMPILER_UNDER_TEST(COMPILER_RUN_MODE.CI);
+            let threw = false;
+
+            try
+                cut.set_runtime_path("/tmp/ghul-test-this-path-must-not-exist.dll");
+            catch ex: Exception
+                threw = true;
+            yrt
+
+            should(threw).be(true, null, null);
+        si
+    si
+si


### PR DESCRIPTION
Enhancements:
- New `--runtime-dll <path>` CLI flag and `GHUL_RUNTIME_DLL` env var that override the runtime DLL the test binary executes against. Flag wins over env var; both take precedence over the per-mode default. Fail fast with a clear error if the supplied path doesn't exist.

Technical:
- Lets the ghul/ CI integration_tests job point at the runtime that ships with the compiler-under-test (the bootstrap-tool artefact) instead of whatever `ghul.runtime` `ghul.test` was packaged with — so a compiler change requiring a newer runtime API no longer needs `ghul.test` to be republished first.
- Has no effect under `--use-dotnet-build`, which resolves the runtime via the test project's own `PackageReference`.