### PR TITLE
Bump pinned ghul.runtime 1.3.5 → 1.3.6

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -1,7 +1,7 @@
 <Project>
   <ItemGroup>
     <!-- ghūl runtime -->
-    <PackageVersion Include="ghul.runtime" Version="1.3.5" />
+    <PackageVersion Include="ghul.runtime" Version="1.3.6" />
 
     <!-- ghūl compiler dependencies -->
     <PackageVersion Include="System.Reflection.MetadataLoadContext" Version="8.0.0" />


### PR DESCRIPTION
Aligns ghul-test's own runtime ref with the published 1.3.6 ahead of the compiler's `xs |` parser switch (degory/ghul#1261). Without this, the next ghul-test republish under a post-#1261 compiler would emit `Ghul.Pipes.pipe(receiver)` desugar against the older runtime that doesn't expose `pipe` cross-assembly, and the build would fail.

Source unchanged; 54/54 unit + integration smoke pass against 1.3.6.