### PR TITLE
Fix release job stuck queued by switching off ubuntu-20.04

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -93,7 +93,7 @@ jobs:
   create_release:
     needs: [version, build]
     name: Create release
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
 
     timeout-minutes: 5
     if: ${{ github.event_name == 'push' }}


### PR DESCRIPTION
Bugs fixed:
- Release job sat queued indefinitely because `runs-on: ubuntu-20.04` is no longer a supported runner image. Switched to `ubuntu-latest` to match the other jobs.