### PR TITLE
Migrate string concat to interpolation; bump ghul.runtime 1.3.6 → 2.0.1

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -1,7 +1,7 @@
 <Project>
   <ItemGroup>
     <!-- ghūl runtime -->
-    <PackageVersion Include="ghul.runtime" Version="1.3.6" />
+    <PackageVersion Include="ghul.runtime" Version="2.0.1" />
 
     <!-- ghūl compiler dependencies -->
     <PackageVersion Include="System.Reflection.MetadataLoadContext" Version="8.0.0" />

--- a/src/compiler-under-test.ghul
+++ b/src/compiler-under-test.ghul
@@ -39,7 +39,7 @@ namespace Tester is
                 _runtime_path = get_published_compiler_path("ghul-runtime.dll");
                 _arguments = ["--v3", "--test-run"];
             else
-                throw new Exception("unknown run mode: " + _run_mode);
+                throw new Exception("unknown run mode: {_run_mode}");
             fi
         si
 
@@ -51,7 +51,7 @@ namespace Tester is
             fi
 
             if !File.exists(path) then
-                throw new Exception("runtime DLL not found: " + path);
+                throw new Exception("runtime DLL not found: {path}");
             fi
 
             _runtime_path = Path.get_full_path(path);
@@ -167,8 +167,7 @@ namespace Tester is
                 return result;
             fi
 
-            throw new Exception("Could not find published compiler: " 
-                + get_published_compiler_path("[ghul|ghul.exe]"));
+            throw new Exception("Could not find published compiler: {get_published_compiler_path("[ghul|ghul.exe]")}");
         si
         
         get_published_compiler_path(file_name: string) -> string =>

--- a/src/main.ghul
+++ b/src/main.ghul
@@ -78,7 +78,7 @@ namespace Tester is
 
             for path in test_paths do
                 if !Directory.exists(path) then
-                    Std.write_line("not a directory: " + path);
+                    Std.write_line("not a directory: {path}");
                     return 1;
                 fi
 
@@ -87,23 +87,23 @@ namespace Tester is
 
             queue.run_queued_tests();
 
-            Std.write_line("" + queue.count + " tests discovered");
-            Std.write_line("" + queue.executed_count + " tests enabled");
-            Std.write_line("" + queue.pass_count + "/" + queue.executed_count + " tests passed");
+            Std.write_line("{queue.count} tests discovered");
+            Std.write_line("{queue.executed_count} tests enabled");
+            Std.write_line("{queue.pass_count}/{queue.executed_count} tests passed");
 
             if queue.fail_count == 0 then
-                Std.write_line("" + cast char(9989) + " all tests passed " + cast char(9989));
+                Std.write_line("{cast char(9989)} all tests passed {cast char(9989)}");
                 return 0;
             fi
-            
-            Std.write_line("" + cast char(10060) + " " + queue.fail_count + " tests failed " + cast char(10060));
+
+            Std.write_line("{cast char(10060)} {queue.fail_count} tests failed {cast char(10060)}");
 
             return 1;
         si
 
         report_host_and_target(host: string, target: string) static is
-            Std.write_line("compiler hosted on: " + get_cli_description(host));
-            Std.write_line("built tests executed on: " + get_cli_description(target));
+            Std.write_line("compiler hosted on: {get_cli_description(host)}");
+            Std.write_line("built tests executed on: {get_cli_description(target)}");
         si
 
         get_cli_description(name: string) -> string static is
@@ -113,7 +113,7 @@ namespace Tester is
                 return ".NET";
             fi
 
-            throw new Exception("unknown CLI environment: " + name);
+            throw new Exception("unknown CLI environment: {name}");
         si
                 
         get_cli_environment_variable(name: string) -> string static is

--- a/src/result.ghul
+++ b/src/result.ghul
@@ -21,7 +21,7 @@ namespace Tester is
             fi            
         si
 
-        progress_string: string => progress.to_string().pad_left(2) + "%";
+        progress_string: string => "{progress.to_string().pad_left(2)}%";
 
         is_pass: bool is
             throw new System.NotImplementedException();            
@@ -45,10 +45,10 @@ namespace Tester is
         si
         
         format(test_name: string) -> string is
-            let result = progress_string + " " + head + ": " + test_name;
+            let result = "{progress_string} {head}: {test_name}";
 
             if body? /\ body !~ "" then
-                result = result + ": " + body;
+                result = "{result}: {body}";
             fi
 
             return result;

--- a/src/runner.ghul
+++ b/src/runner.ghul
@@ -94,7 +94,7 @@ namespace Tester is
 
             if build_succeeded then
                 if _test.is_build_fail_expected then
-                    add_fail("unexpected build success: " + _test.path);
+                    add_fail("unexpected build success: {_test.path}");
                     exit_after_grep_and_sort = true;
                 fi
             else
@@ -164,7 +164,7 @@ namespace Tester is
             let binary_path = _compiler_under_test.get_binary_path(self);
 
             if !File.exists(binary_path) then
-                add_fail("no binary found: " + binary_path);
+                add_fail("no binary found: {binary_path}");
                 return false;
             fi
 
@@ -182,7 +182,7 @@ namespace Tester is
             if 
                 exit_status != 0
             then
-                add_fail("binary exited with non-zero status (" + exit_status + ")", "run.err");
+                add_fail("binary exited with non-zero status ({exit_status})", "run.err");
                 return false;
             fi
 
@@ -337,7 +337,7 @@ namespace Tester is
             let result = Process.start(start_info);
 
             if result == null then
-                throw new Exception("failed to start process: " + path + " " + start_info.arguments);
+                throw new Exception("failed to start process: {path} {start_info.arguments}");
             fi
             
             return result;
@@ -418,7 +418,7 @@ namespace Tester is
             let file_path = get_path(file_name);
 
             if !File.exists(file_path) then
-                return "(could not read file: " + file_path + ")";
+                return "(could not read file: {file_path})";
             fi
             
             return File.read_all_text(get_path(file_name));

--- a/src/test-queue.ghul
+++ b/src/test-queue.ghul
@@ -53,7 +53,7 @@ namespace Tester is
             
             _task_queue = new TASK_QUEUE(actual_test_processes);
 
-            Std.write_line("using " + actual_test_processes + " processes to run tests");
+            Std.write_line("using {actual_test_processes} processes to run tests");
 
             _tests = new LIST[TEST]();
         si
@@ -112,13 +112,13 @@ namespace Tester is
                     try_queue_tests(entry);
                 od
             catch ex: Exception
-                Std.write_line("probably not a directory: " + path);
-                Std.write_line("caught: " + ex);
+                Std.write_line("probably not a directory: {path}");
+                Std.write_line("caught: {ex}");
             yrt            
         si
 
         try_queue_test(path: string) is
-            let flags_path = path + "/ghulflags";
+            let flags_path = "{path}/ghulflags";
 
             if !File.exists(flags_path) then
                 return;
@@ -126,7 +126,7 @@ namespace Tester is
 
             let flags = File.read_all_text(flags_path);
             let source_files = get_source_files(path);
-            let is_build_failure_Expected = File.exists(path + "/fail.expected");
+            let is_build_failure_Expected = File.exists("{path}/fail.expected");
 
             queue_test(
                 new TEST(

--- a/src/test.ghul
+++ b/src/test.ghul
@@ -31,7 +31,7 @@ namespace Tester is
             if result? then
                 return result.format(path);  
             else
-                return "no result: " + path;
+                return "no result: {path}";
             fi
             
             return path;


### PR DESCRIPTION
Technical:
- Replaces `+(string, object)` overload uses throughout `src/` with string interpolation. Mechanical conversion (`"label: " + x` → `"label: {x}"`, `prefix + "/" + suffix` → `"{prefix}/{suffix}"`, etc.).
- Bumps `ghul.runtime` pin 1.3.6 → 2.0.1.
- 54/54 unit tests pass. Zero remaining `+(string, object)` sites under `--warn-deprecated-string-plus`.
- Preparatory work for removing the `+(string, object) -> string` overload from the compiler in a future release.