### PR TITLE
Bump pinned compiler 0.8.47 → 0.9.1; migrate remaining tests/src `+ string` to interpolation

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -3,7 +3,7 @@
   "isRoot": true,
   "tools": {
     "ghul.compiler": {
-      "version": "0.8.47",
+      "version": "0.9.1",
       "commands": [
         "ghul-compiler"
       ]

--- a/tests/src/results.ghul
+++ b/tests/src/results.ghul
@@ -205,7 +205,7 @@ namespace Tests is
             
             let skip = new SKIP(get_stub_test());
 
-            should(skip.format("xx a test name xx")).be(skip.progress_string + " " + skip.head + ": xx a test name xx", null, null);
+            should(skip.format("xx a test name xx")).be("{skip.progress_string} {skip.head}: xx a test name xx", null, null);
         si
 
         SKIP__to_string__given_test_path__to_string__returns_formatted_path() is
@@ -281,7 +281,7 @@ namespace Tests is
             
             let pass = new PASS(get_stub_test());
 
-            should(pass.format("xx a test name xx")).be(pass.progress_string + " " + pass.head + ": xx a test name xx", null, null);
+            should(pass.format("xx a test name xx")).be("{pass.progress_string} {pass.head}: xx a test name xx", null, null);
         si
 
         PASS__to_string__given_test_path__returns_formatted_path() is
@@ -367,7 +367,7 @@ namespace Tests is
             @test()
             
             let fail = new FAILURE(get_stub_test());
-            let details = [1, 2, 3] | .map(i => new DETAILS("something went wrong " + i));
+            let details = [1, 2, 3] | .map(i => new DETAILS("something went wrong {i}"));
 
             for d in details do
                 fail.add(d);                
@@ -381,7 +381,7 @@ namespace Tests is
             
             let fail = new FAILURE(get_stub_test());
 
-            should(fail.format("xx a test name xx")).be(fail.progress_string + " " + fail.head + ": xx a test name xx", null, null);
+            should(fail.format("xx a test name xx")).be("{fail.progress_string} {fail.head}: xx a test name xx", null, null);
         si
 
         FAILURE__to_string__given_test_path__returns_formatted_path() is

--- a/tests/src/runner.ghul
+++ b/tests/src/runner.ghul
@@ -101,10 +101,10 @@ namespace Tests is
                     "_collate_environment"
                 );
 
-            Std.error.write_line("field_value: " + field_value);
+            Std.error.write_line("field_value: {field_value}");
 
             if field_value? then
-                Std.error.write_line("field_value type: " + field_value.get_type().to_string());
+                Std.error.write_line("field_value type: {field_value.get_type().to_string()}");
             fi
 
             should(isa Map[string,string](field_value)).be_true(null, null);


### PR DESCRIPTION
Technical:
- Compiler pin in `.config/dotnet-tools.json` 0.8.47 → 0.9.1. Picks up the post-0.8.47 compiler releases including the `+(string, object) -> string` overload removal in 0.9.0 (degory/ghul#1274).
- Migrates the six remaining `+ string` sites in `tests/src/results.ghul` and `tests/src/runner.ghul`. The `src/` migration was done in #111; `tests/` was out of that PR's scope but needs the same treatment so the test project builds under the 0.9.1 compiler.
- 54/54 unit tests and both integration test groups pass under the new pin.