### PR TITLE
Migrate ghul-test/src to trailing `mut` for reassigned local bindings

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -3,7 +3,7 @@
   "isRoot": true,
   "tools": {
     "ghul.compiler": {
-      "version": "0.9.1",
+      "version": "0.9.5",
       "commands": [
         "ghul-compiler"
       ]

--- a/src/compiler-under-test.ghul
+++ b/src/compiler-under-test.ghul
@@ -68,8 +68,7 @@ namespace Tester is
                 );
             fi
 
-            let result = -1;
-
+            let result mut = -1;
             if _run_mode == COMPILER_RUN_MODE.DOTNET then
                 result = runner.run(
                     _executable,
@@ -155,8 +154,7 @@ namespace Tester is
         si
 
         find_published_compiler() -> string is
-            let result = get_published_compiler_path("ghul");
-
+            let result mut = get_published_compiler_path("ghul");
             if File.exists(result) then
                 return result;
             fi

--- a/src/main.ghul
+++ b/src/main.ghul
@@ -29,22 +29,19 @@ namespace Tester is
             let ci_string = 
                 System.Environment.get_environment_variable("CI");
 
-            let run_mode = COMPILER_RUN_MODE.LOCAL;
-
-            if 
+            let run_mode mut = COMPILER_RUN_MODE.LOCAL;
+            if
                 !string.is_null_or_white_space(ci_string) /\
                 (ci_string =~ "1" \/ ci_string.to_lower() =~ "true")
             then
                 run_mode = COMPILER_RUN_MODE.CI;
             fi
 
-            let runtime_dll_override =
-                System.Environment.get_environment_variable("GHUL_RUNTIME_DLL");
+            let runtime_dll_override mut =                System.Environment.get_environment_variable("GHUL_RUNTIME_DLL");
 
             let test_paths = new LIST[string]();
 
-            let i = 0;
-            while i < arguments.count do
+            let i mut = 0;            while i < arguments.count do
                 let arg = arguments[i];
 
                 if arg =~ "--use-dotnet-build" then
@@ -117,8 +114,7 @@ namespace Tester is
         si
                 
         get_cli_environment_variable(name: string) -> string static is
-            let result = System.Environment.get_environment_variable(name);
-
+            let result mut = System.Environment.get_environment_variable(name);
             if !result? then
                 result = "dotnet";
             fi

--- a/src/result.ghul
+++ b/src/result.ghul
@@ -45,8 +45,7 @@ namespace Tester is
         si
         
         format(test_name: string) -> string is
-            let result = "{progress_string} {head}: {test_name}";
-
+            let result mut = "{progress_string} {head}: {test_name}";
             if body? /\ body !~ "" then
                 result = "{result}: {body}";
             fi

--- a/src/runner.ghul
+++ b/src/runner.ghul
@@ -90,8 +90,7 @@ namespace Tester is
 
             let build_succeeded = _compiler_under_test.run_compiler(self, _test);
 
-            let exit_after_grep_and_sort = false;
-
+            let exit_after_grep_and_sort mut = false;
             if build_succeeded then
                 if _test.is_build_fail_expected then
                     add_fail("unexpected build success: {_test.path}");
@@ -229,10 +228,10 @@ namespace Tester is
         si
         
         run_diff(
-            description: string, 
-            expected_file_name: string, 
-            actual_file_name: string, 
-            out_file_name: string, 
+            description: string,
+            expected_file_name: string mut,
+            actual_file_name: string,
+            out_file_name: string,
             ignore_space_changes: bool
         ) -> bool
         is
@@ -252,8 +251,7 @@ namespace Tester is
                 return false;
             fi
 
-            let args: string[];
-
+            let args: string[] mut;
             if ignore_space_changes then
                 args = ["-b", "--strip-trailing-cr", expected_file_name, actual_file_name];
             else
@@ -364,8 +362,7 @@ namespace Tester is
         si
         
         add_fail(message: string, file_name: string) is
-            let details: DETAILS;
-
+            let details: DETAILS mut;
             if file_name? then
                 details = new DETAILS(message, read_all_text_quiet(file_name));
             else

--- a/src/test-queue.ghul
+++ b/src/test-queue.ghul
@@ -37,8 +37,7 @@ namespace Tester is
 
             let requested_test_processes = System.Environment.get_environment_variable("TEST_PROCESSES");
 
-            let actual_test_processes: int;
-
+            let actual_test_processes: int mut;
             if requested_test_processes? then
                 actual_test_processes = System.Convert.to_int32(requested_test_processes);                
             else
@@ -75,8 +74,7 @@ namespace Tester is
                 report_progress(results);
             od
 
-            let results = _task_queue.drain();
-
+            let results mut = _task_queue.drain();
             while results? do
                 report_progress(results);
                 results = _task_queue.drain();


### PR DESCRIPTION
Follow-up to ghul#1124: bare `let` bindings that are subsequently reassigned are flagged by the new `--warn-implicit-mutable-let` warning; each such site in ghul-test/src is rewritten to declare with trailing `mut` (`<binding> mut`, matching the existing `name: type public` modifier-after-name convention).

Enhancements:
- 13 reassigned bindings now declare with trailing `mut`:
  - `src/compiler-under-test.ghul:71,158` — `result` (run + find).
  - `src/main.ghul:32,41,46,120` — `run_mode`, `runtime_dll_override`, loop index `i`, `result` in `get_cli_environment_variable`.
  - `src/result.ghul:48` — `result` in `format`.
  - `src/runner.ghul:93,367` — `exit_after_grep_and_sort`, `details` (deferred-init in `add_fail` overload).
  - `src/runner.ghul:233` — `expected_file_name: string mut` in `run_diff`'s parameter list. The per-variable parser position naturally supports `f(x: T mut)`, so the parameter is marked directly without a local shadow.
  - `src/runner.ghul:259` — `args: string[] mut` (deferred-init).
  - `src/test-queue.ghul:40,78` — `actual_test_processes` (deferred-init from CPU heuristics), `results` (drain loop).

Technical:
- Compiler pin bumped to 0.9.5 (first published release supporting `let mut`).
- No IL change — `<binding> mut` is identical to bare `<binding>` at the IL level; the difference is purely a source-level marker consumed by the warning emitter to opt out of the warning.
- 54/54 unit tests + integration tests pass under 0.9.5. Zero remaining `--warn-implicit-mutable-let` warnings.