### PR TITLE
Restore line breaks the phase B migration script collapsed

### DIFF
--- a/src/compiler-under-test.ghul
+++ b/src/compiler-under-test.ghul
@@ -69,6 +69,7 @@ namespace Tester is
             fi
 
             let result mut = -1;
+
             if _run_mode == COMPILER_RUN_MODE.DOTNET then
                 result = runner.run(
                     _executable,
@@ -155,6 +156,7 @@ namespace Tester is
 
         find_published_compiler() -> string is
             let result mut = get_published_compiler_path("ghul");
+
             if File.exists(result) then
                 return result;
             fi

--- a/src/main.ghul
+++ b/src/main.ghul
@@ -30,6 +30,7 @@ namespace Tester is
                 System.Environment.get_environment_variable("CI");
 
             let run_mode mut = COMPILER_RUN_MODE.LOCAL;
+
             if
                 !string.is_null_or_white_space(ci_string) /\
                 (ci_string =~ "1" \/ ci_string.to_lower() =~ "true")
@@ -37,11 +38,14 @@ namespace Tester is
                 run_mode = COMPILER_RUN_MODE.CI;
             fi
 
-            let runtime_dll_override mut =                System.Environment.get_environment_variable("GHUL_RUNTIME_DLL");
+            let runtime_dll_override mut =
+                System.Environment.get_environment_variable("GHUL_RUNTIME_DLL");
 
             let test_paths = new LIST[string]();
 
-            let i mut = 0;            while i < arguments.count do
+            let i mut = 0;
+
+            while i < arguments.count do
                 let arg = arguments[i];
 
                 if arg =~ "--use-dotnet-build" then
@@ -115,6 +119,7 @@ namespace Tester is
                 
         get_cli_environment_variable(name: string) -> string static is
             let result mut = System.Environment.get_environment_variable(name);
+
             if !result? then
                 result = "dotnet";
             fi

--- a/src/result.ghul
+++ b/src/result.ghul
@@ -46,6 +46,7 @@ namespace Tester is
         
         format(test_name: string) -> string is
             let result mut = "{progress_string} {head}: {test_name}";
+
             if body? /\ body !~ "" then
                 result = "{result}: {body}";
             fi

--- a/src/runner.ghul
+++ b/src/runner.ghul
@@ -91,6 +91,7 @@ namespace Tester is
             let build_succeeded = _compiler_under_test.run_compiler(self, _test);
 
             let exit_after_grep_and_sort mut = false;
+
             if build_succeeded then
                 if _test.is_build_fail_expected then
                     add_fail("unexpected build success: {_test.path}");
@@ -252,6 +253,7 @@ namespace Tester is
             fi
 
             let args: string[] mut;
+
             if ignore_space_changes then
                 args = ["-b", "--strip-trailing-cr", expected_file_name, actual_file_name];
             else
@@ -363,6 +365,7 @@ namespace Tester is
         
         add_fail(message: string, file_name: string) is
             let details: DETAILS mut;
+
             if file_name? then
                 details = new DETAILS(message, read_all_text_quiet(file_name));
             else

--- a/src/test-queue.ghul
+++ b/src/test-queue.ghul
@@ -38,6 +38,7 @@ namespace Tester is
             let requested_test_processes = System.Environment.get_environment_variable("TEST_PROCESSES");
 
             let actual_test_processes: int mut;
+
             if requested_test_processes? then
                 actual_test_processes = System.Convert.to_int32(requested_test_processes);                
             else
@@ -75,6 +76,7 @@ namespace Tester is
             od
 
             let results mut = _task_queue.drain();
+
             while results? do
                 report_progress(results);
                 results = _task_queue.drain();


### PR DESCRIPTION
Bugs fixed:
- The bulk-rewrite script that introduced trailing `mut` in #113 ate two newlines in `src/main.ghul`: `let runtime_dll_override mut =` lost its RHS continuation (the call to `Environment.get_environment_variable` ended up appended after a run of spaces on the same line), and `let i mut = 0;` collapsed onto the same line as the following `while i < arguments.count do`. Restored in both cases.
- Same script also removed the blank line between `let X mut = ...;` and the following statement in nine places (`src/compiler-under-test.ghul:71,158`; `src/main.ghul:32,121`; `src/result.ghul:48`; `src/runner.ghul:93,254,365`; `src/test-queue.ghul:40,77`). Restored.

Technical:
- 54/54 unit tests pass under 0.9.5; no semantic change.