### PR TITLE
Switch devcontainer image to standard MS .NET 8

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,5 +1,5 @@
 {
-	"image": "ghcr.io/degory/ghul/devcontainer:dotnet",
+	"image": "mcr.microsoft.com/devcontainers/dotnet:8.0",
 	"containerUser": "vscode",
 	"extensions": [
 		"degory.ghul"


### PR DESCRIPTION
The custom `ghcr.io/degory/ghul/devcontainer:dotnet` image was providing a system-wide install of `ghul.compiler` that the local tool manifest shadowed anyway, plus a `vscode` non-root user that `mcr.microsoft.com/devcontainers/dotnet:8.0` already provides. Switching to the standard MS image removes the dependency on a bespoke image without losing anything used in practice.

Technical:

- `.devcontainer/devcontainer.json` points at `mcr.microsoft.com/devcontainers/dotnet:8.0`. The compiler is installed from the tool manifest on first `dotnet tool restore`.

Sibling PRs (same theme): degory/ghul, degory/ghul-runtime, degory/ghul-examples, degory/ghul-dev.